### PR TITLE
Add containerip,port to more ipsets according to service name and tags

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -46,6 +46,8 @@ func ipsetRun(ipcmd string) error {
 }
 
 func ipsetHost(command string, set string, ip string, proto string, port string) error {
+	_ = ipsetInitWithHash(set, "ip,port")
+
 	cmd := "-! " + command + " " + set + " " + ip + "," + proto + ":" + port
 	log.Println("ipsetHost()", cmd)
 	err := ipsetRun(cmd)
@@ -81,7 +83,20 @@ func iptablesInit(chain string, set string) error {
 }
 
 func ipsetInit(set string) error {
-	err := ipsetRun("-! create " + set + " hash:ip,port family inet6")
+	err := ipsetInitAndFlushWithHash(set, "ip,port")
+	return err
+}
+
+func ipsetInitWithHash(set string, hash string) error {
+	err := ipsetRun("-! create " + set + " hash:" + hash + " family inet6")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ipsetInitAndFlushWithHash(set string, hash string) error {
+	err := ipsetInitWithHash(set, hash)
 	if err != nil {
 		return err
 	}

--- a/netfilter.go
+++ b/netfilter.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gliderlabs/registrator/bridge"
+	"github.com/42wim/registrator-work/bridge"
 )
 
 func init() {
@@ -23,12 +23,15 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 		chain = "FORWARD_direct"
 		set = "containerports"
 	}
-	FirewalldInit()
-	if firewalldRunning {
-		OnReloaded(func() { iptablesInit(chain, set) })
-	}
 	ipsetInit(set)
-	iptablesInit(chain, set)
+
+	if chain != "-" {
+		FirewalldInit()
+		if firewalldRunning {
+			OnReloaded(func() { iptablesInit(chain, set) })
+		}
+		iptablesInit(chain, set)
+	}
 	return &NetfilterAdapter{Chain: chain, Set: set}
 }
 
@@ -41,20 +44,50 @@ func (r *NetfilterAdapter) Ping() error {
 	return nil
 }
 
+func (r *NetfilterAdapter) SetsForHost(service *bridge.Service) []string {
+	name := service.Name
+	port := strconv.Itoa(service.Port)
+	tags := service.Tags
+
+	sets := []string{
+		// default set
+		r.Set,
+		// service_name
+		name,
+		// service_name/service_port
+		name + "/" + port,
+	}
+
+	for _, t := range tags {
+		// service_name/service_tag, service_name/service_tag/service_port
+		sets = append(sets, name+"/"+t, name+"/"+t+"/"+port)
+	}
+
+	return sets
+}
+
 func (r *NetfilterAdapter) Register(service *bridge.Service) error {
 	if strings.Contains(service.IP, ":") {
-		return ipsetHost("add", r.Set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
-	} else {
-		return nil
+		for _, set := range r.SetsForHost(service) {
+			err := ipsetHost("add", set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
+			if err != nil {
+				return err
+			}
+		}
 	}
+	return nil
 }
 
 func (r *NetfilterAdapter) Deregister(service *bridge.Service) error {
 	if strings.Contains(service.IP, ":") {
-		return ipsetHost("del", r.Set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
-	} else {
-		return nil
+		for _, set := range r.SetsForHost(service) {
+			err := ipsetHost("del", set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
+			if err != nil {
+				return err
+			}
+		}
 	}
+	return nil
 }
 
 func (r *NetfilterAdapter) Refresh(service *bridge.Service) error {


### PR DESCRIPTION
This allows you to make very fine iptables rules (but you have to make
those yourself); also, it is now optional to add the main iptables rule
that allows all traffic to all exposed container ports (so you can be
more specific as to who etc.)
